### PR TITLE
Update version comparison syntax

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
 - name: test java version
   fail:
     msg: "this installation of solr requires java version {{ solr_minimum_java_version }} or higher"
-  when: "not returned_java_version | version_compare(solr_minimum_java_version, '>=')"
+  when: "not returned_java_version is version(solr_minimum_java_version, '>=')"
 
 - name: add solr user group
   group:


### PR DESCRIPTION
Duplicating https://github.com/jhu-library-applications/catalyst-ansible/pull/61

The syntax for doing a conditional based
on a version number has changed in ansible
2.9.x and this line will fail now.

This changes it to use the newer syntax.

See ansible/ansible#64174